### PR TITLE
Only return :type=>okta_group groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+* Fix returned group hash - previously the first group that matched the name was returned, now we only return groups with `:type => okta_group`
+
 ## 0.1.1 (2018-03-06)
 
 ### Fixed

--- a/lib/chef/knife/data_bag_from_okta_group.rb
+++ b/lib/chef/knife/data_bag_from_okta_group.rb
@@ -266,7 +266,7 @@ class Chef
       end
 
       def group_hash(group_name)
-        group_hash = groups.select { |group| group[:profile][:name] =~ /^#{group_name}$/i }.shift
+        group_hash = groups.select { |group| group[:type] == "OKTA_GROUP" && group[:profile][:name] =~ /^#{group_name}$/i }.shift
         if group_hash.nil?
           ui.fatal("Cannot find a group with the name \"#{group_name}\" in the specified Okta tenant")
           exit(1)


### PR DESCRIPTION
When the Okta tenant contains multiple group types with the same name (e.g. an Okta group and an Office 365 group), the first group found was always returned which may not contain the users you want.

This PR only returns groups with a type of `OKTA_GROUP` to fix the above.